### PR TITLE
Update for Gazebo 9 and ROS Melodic (WIP)

### DIFF
--- a/include/pal_gazebo_plugins/gazebo_harness.h
+++ b/include/pal_gazebo_plugins/gazebo_harness.h
@@ -50,6 +50,7 @@
 // Gazebo
 #include <gazebo/common/common.hh>
 #include <gazebo/physics/physics.hh>
+#include <ignition/math.hh>
 #include <ros/ros.h>
 #include <ros/callback_queue.h>
 #include <std_msgs/String.h>
@@ -103,8 +104,8 @@ namespace gazebo {
                                       physics::LinkPtr _link1,
                                       physics::LinkPtr _link2,
                                       std::string _type,
-                                      math::Vector3 _anchor,
-                                      math::Vector3 _axis,
+                                      ignition::math::Vector3<double> _anchor,
+                                      ignition::math::Vector3<double> _axis,
                                       double _upper, double _lower);
     /// \brief Remove a joint.
     /// \param[in] _joint Joint to remove.

--- a/include/pal_gazebo_plugins/gazebo_ros_forcetorque.h
+++ b/include/pal_gazebo_plugins/gazebo_ros_forcetorque.h
@@ -55,7 +55,7 @@
 
 #include <boost/thread.hpp>
 
-#include <gazebo/math/Vector3.hh>
+#include <ignition/math/Vector3.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/physics/PhysicsTypes.hh>
 #include <gazebo/transport/TransportTypes.hh>
@@ -115,8 +115,8 @@ namespace gazebo
     private: ros::CallbackQueue rosQueue;
     private: boost::thread callbackQueeuThread;
 
-    private: math::Vector3 footForce;
-    private: math::Vector3 footTorque;
+    private: ignition::math::Vector3<double> footForce;
+    private: ignition::math::Vector3<double> footTorque;
 
     // Controls stuff
     private: ros::Time lastUpdateTime;

--- a/include/pal_gazebo_plugins/gazebo_underactuated_finger.h
+++ b/include/pal_gazebo_plugins/gazebo_underactuated_finger.h
@@ -77,7 +77,7 @@ namespace gazebo {
 
       std::vector<double> scale_factors_;
 
-      math::Angle actuator_angle_;
+      double actuator_angle_;
 
       std::string robot_namespace_;
 

--- a/src/gazebo_attachment.cpp
+++ b/src/gazebo_attachment.cpp
@@ -6,7 +6,7 @@
   @copyright (c) 2018 PAL Robotics SL. All Rights Reserved
 */
 #include <pal_gazebo_plugins/gazebo_attachment.h>
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 #include <sdf/sdf.hh>
 #include <ros/ros.h>
 
@@ -62,9 +62,15 @@ void GazeboAttachment::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 
 void gazebo::GazeboAttachment::createJoint()
 {
-  const auto p = this->target_link_->GetWorldPose();
-  ignition::math::Pose3d target_link_pose =
-      ignition::math::Pose3d(p.pos.x, p.pos.y, p.pos.z, p.rot.w, p.rot.x, p.rot.y, p.rot.z);
+  const auto p = this->target_link_->WorldPose();
+  ignition::math::Pose3d target_link_pose = ignition::math::Pose3d(
+    p.Pos().X(),
+    p.Pos().Y(),
+    p.Pos().Z(),
+    p.Rot().W(),
+    p.Rot().X(),
+    p.Rot().Y(),
+    p.Rot().Z());
 
   ignition::math::Pose3d target_pose = ignition::math::Pose3d(
       target_link_pose.Pos() + target_link_pose.Rot().RotateVector(this->pose_.Pos()),
@@ -72,12 +78,12 @@ void gazebo::GazeboAttachment::createJoint()
   this->model_->SetLinkWorldPose(target_pose, this->local_link_);
 
   physics::JointPtr joint =
-      this->world_->GetPhysicsEngine()->CreateJoint("revolute", this->model_);
+      this->world_->Physics()->CreateJoint("revolute", this->model_);
   joint->Attach(this->local_link_, this->target_link_);
-  joint->Load(this->local_link_, this->target_link_, math::Pose());
+  joint->Load(this->local_link_, this->target_link_, ignition::math::Pose3d());
   joint->SetModel(this->model_);
-  joint->SetHighStop(0, 0);
-  joint->SetLowStop(0, 0);
+  joint->SetUpperLimit(0, 0.0);
+  joint->SetLowerLimit(0, 0.0);
   joint->Init();
 }
 
@@ -86,7 +92,7 @@ void GazeboAttachment::OnUpdate(const common::UpdateInfo &)
   ROS_INFO_STREAM_THROTTLE(5.0, "Attempting to attach " << this->target_model_name_
                                                         << "::" << this->target_link_name_
                                                         << " to " << this->local_link_name_);
-  this->target_model_ = this->world_->GetModel(this->target_model_name_);
+  this->target_model_ = this->world_->ModelByName(this->target_model_name_);
   if (!this->target_model_.get())
   {
     ROS_ERROR_STREAM_DELAYED_THROTTLE(5.0, "gazebo_attachment plugin got non-existing target_model_name: "
@@ -111,7 +117,7 @@ void GazeboAttachment::OnUpdate(const common::UpdateInfo &)
   }
 
   createJoint();
-  event::Events::DisconnectWorldUpdateBegin(this->connection_);
+  // event::Events::DisconnectWorldUpdateBegin(this->connection_);
 }
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboAttachment)

--- a/src/gazebo_harness.cpp
+++ b/src/gazebo_harness.cpp
@@ -44,7 +44,6 @@
 
 #include <assert.h>
 #include <pal_gazebo_plugins/gazebo_harness.h>
-#include <gazebo/math/gzmath.hh>
 #include <sdf/sdf.hh>
 #include <ros/ros.h>
 
@@ -163,12 +162,19 @@ namespace gazebo {
       // pinning robot, and turning on effect of gravity
       if (!this->pinJoint_)
       {
-        math::Pose robot_pose = this->pinLink_->GetWorldPose();
-        robot_pose.pos.z += 0.2;
+        ignition::math::Pose3d robot_pose = this->pinLink_->WorldPose();
+        robot_pose += ignition::math::Pose3d(0.0, 0.0, 0.2, 0.0, 0.0, 0.0);
         this->robot_ptr_->SetLinkWorldPose(robot_pose, this->pinLink_);
-        this->pinJoint_ = this->AddJoint(this->world_, this->robot_ptr_,
-                                         physics::LinkPtr(),    this->pinLink_,
-                                         "revolute", math::Vector3(0.0, 0.0, 0.0), math::Vector3(0, 0, 1), 0.0, 0.0);
+        this->pinJoint_ = this->AddJoint(
+          this->world_,
+          this->robot_ptr_,
+          physics::LinkPtr(),
+          this->pinLink_,
+          "revolute",
+          ignition::math::Vector3<double>(0.0, 0.0, 0.0),
+          ignition::math::Vector3<double>(0.0, 0.0, 1.0),
+          0.0,
+          0.0);
       }
       ROS_ERROR_STREAM("Setting gravity on");
       physics::Link_V links = this->robot_ptr_->GetLinks();
@@ -207,20 +213,20 @@ namespace gazebo {
                                             physics::LinkPtr _link1,
                                             physics::LinkPtr _link2,
                                             std::string _type,
-                                            math::Vector3 _anchor,
-                                            math::Vector3 _axis,
+                                            ignition::math::Vector3<double> _anchor,
+                                            ignition::math::Vector3<double> _axis,
                                             double _upper, double _lower)
   {
-    physics::JointPtr joint = _world->GetPhysicsEngine()->CreateJoint(
+    physics::JointPtr joint = _world->Physics()->CreateJoint(
           _type, _model);
     joint->Attach(_link1, _link2);
     // load adds the joint to a vector of shared pointers kept
     // in parent and child links, preventing joint from being destroyed.
-    joint->Load(_link1, _link2, math::Pose(_anchor, math::Quaternion()));
+    joint->Load(_link1, _link2, ignition::math::Pose3d(_anchor, ignition::math::Quaternion<double>()));
     // joint->SetAnchor(0, _anchor);
     joint->SetAxis(0, _axis);
-    joint->SetHighStop(0, _upper);
-    joint->SetLowStop(0, _lower);
+    joint->SetUpperLimit(0, _upper);
+    joint->SetLowerLimit(0, _lower);
     if (_link1)
       joint->SetName(_link1->GetName() + std::string("_") +
                      _link2->GetName() + std::string("_joint"));

--- a/src/gazebo_pal_hand.cpp
+++ b/src/gazebo_pal_hand.cpp
@@ -40,7 +40,7 @@
 
 #include <pal_gazebo_plugins/gazebo_pal_hand.h>
 
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 #include <sdf/sdf.hh>
 
 #include <ros/ros.h>
@@ -151,24 +151,24 @@ namespace gazebo {
   // Update the controller
   void GazeboPalHand::UpdateChild() {
 
-    math::Angle actuator_angle = joints[0]->GetAngle(0u);
-    math::Angle lower_limit    = math::Angle(0.02);
-    if( actuator_angle > lower_limit)
+    double actuator_angle = joints[0]->Position(0u);
+    double lower_limit = 0.02;
+    if(actuator_angle > lower_limit)
     {
-      math::Angle index_1_angle = ( actuator_angle/2.5 > joints[1]->GetUpperLimit(0u) ) ? joints[1]->GetUpperLimit(0u) : actuator_angle/2.5;
-      joints[1]->SetPosition(0u, index_1_angle.Radian());
+      double index_1_angle = (actuator_angle/2.5 > joints[1]->UpperLimit(0u)) ? joints[1]->UpperLimit(0u) : actuator_angle/2.5;
+      joints[1]->SetPosition(0u, index_1_angle);
 
-      math::Angle index_2_angle = ( actuator_angle/3.2 > joints[2]->GetUpperLimit(0u) ) ? joints[2]->GetUpperLimit(0u) : actuator_angle/3.2;
-      joints[2]->SetPosition(0u, index_2_angle.Radian());
+      double index_2_angle = (actuator_angle/3.2 > joints[2]->UpperLimit(0u)) ? joints[2]->UpperLimit(0u) : actuator_angle/3.2;
+      joints[2]->SetPosition(0u, index_2_angle);
 
-      math::Angle index_3_angle = ( actuator_angle/3.2 > joints[3]->GetUpperLimit(0u) ) ? joints[3]->GetUpperLimit(0u) : actuator_angle/3.2;
-      joints[3]->SetPosition(0u, index_3_angle.Radian());
+      double index_3_angle = (actuator_angle/3.2 > joints[3]->UpperLimit(0u)) ? joints[3]->UpperLimit(0u) : actuator_angle/3.2;
+      joints[3]->SetPosition(0u, index_3_angle);
     }
     else
     {
-      joints[1]->SetPosition(0u, lower_limit.Radian());
-      joints[2]->SetPosition(0u, lower_limit.Radian());
-      joints[3]->SetPosition(0u, lower_limit.Radian());
+      joints[1]->SetPosition(0u, lower_limit);
+      joints[2]->SetPosition(0u, lower_limit);
+      joints[3]->SetPosition(0u, lower_limit);
     }
   }
 

--- a/src/gazebo_ros_forcetorque.cpp
+++ b/src/gazebo_ros_forcetorque.cpp
@@ -54,7 +54,7 @@ FTPlugin::FTPlugin() : SensorPlugin()
 ////////////////////////////////////////////////////////////////////////////////
 FTPlugin::~FTPlugin()
 {
-  event::Events::DisconnectWorldUpdateBegin(this->updateConnection);
+  // event::Events::DisconnectWorldUpdateBegin(this->updateConnection);
   this->rosNode->shutdown();
   this->rosQueue.clear();
   this->rosQueue.disable();
@@ -102,7 +102,7 @@ void FTPlugin::Load(sensors::SensorPtr _sensor,
 //  // Get the world name.
 //  this->world = this->model->GetWorld();
 //  this->sdf = _sdf;
-//  this->lastControllerUpdateTime = this->world->GetSimTime();
+//  this->lastControllerUpdateTime = this->world->SimTime();
 
 //  this->rAnkleJoint = this->model->GetJoint("r_leg_lax");
 //  if (!this->rAnkleJoint)
@@ -170,26 +170,26 @@ void FTPlugin::UpdateChild()
     if ( ( now - this->lastUpdateTime) >= update_period)
     {
 
-        double rate = footContactSensor->GetUpdateRate();
+        double rate = footContactSensor->UpdateRate();
         //ROS_DEBUG("sensor update rate %f, dT elapsed %f [sec]", rate, ( now - this->lastUpdateTime).toSec() ); // TODO: Remove?
 
         this->lastUpdateTime = now;
 
         // Get all the contacts.
         msgs::Contacts contacts;
-        contacts = this->footContactSensor->GetContacts();
+        contacts = this->footContactSensor->Contacts();
 
         for (int i = 0; i < contacts.contact_size(); ++i)
         {
-            math::Vector3 fTotal;
-            math::Vector3 tTotal;
+            ignition::math::Vector3<double> fTotal;
+            ignition::math::Vector3<double> tTotal;
             for (int j = 0; j < contacts.contact(i).position_size(); ++j)
             {
-                fTotal += math::Vector3(
+                fTotal += ignition::math::Vector3<double>(
                             contacts.contact(i).wrench(j).body_1_wrench().force().x(),
                             contacts.contact(i).wrench(j).body_1_wrench().force().y(),
                             contacts.contact(i).wrench(j).body_1_wrench().force().z());
-                tTotal += math::Vector3(
+                tTotal += ignition::math::Vector3<double>(
                             contacts.contact(i).wrench(j).body_1_wrench().torque().x(),
                             contacts.contact(i).wrench(j).body_1_wrench().torque().y(),
                             contacts.contact(i).wrench(j).body_1_wrench().torque().z());
@@ -200,12 +200,12 @@ void FTPlugin::UpdateChild()
             this->footTorque = this->footTorque * e + tTotal * (1.0 - e);
 
             geometry_msgs::Wrench msg;
-            msg.force.x = this->footForce.x;
-            msg.force.y = this->footForce.y;
-            msg.force.z = this->footForce.z;
-            msg.torque.x = this->footTorque.x;
-            msg.torque.y = this->footTorque.y;
-            msg.torque.z = this->footTorque.z;
+            msg.force.x = this->footForce.X();
+            msg.force.y = this->footForce.Y();
+            msg.force.z = this->footForce.Z();
+            msg.torque.x = this->footTorque.X();
+            msg.torque.y = this->footTorque.Y();
+            msg.torque.z = this->footTorque.Z();
             this->pubFootContact.publish(msg);
         }
     }

--- a/src/gazebo_wifi_ap.cpp
+++ b/src/gazebo_wifi_ap.cpp
@@ -36,7 +36,7 @@
 
 #include <assert.h>
 #include <pal_gazebo_plugins/gazebo_wifi_ap.h>
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 #include <sdf/sdf.hh>
 #include <ros/ros.h>
 #include <pal_multirobot_msgs/WifiServiceDetection.h>
@@ -48,7 +48,7 @@ namespace gazebo {
   // Destructor
   GazeboWifiAP::~GazeboWifiAP()
   {
-    event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
+    // event::Events::DisconnectWorldUpdateBegin(this->update_connection_);
     this->rosNode_->shutdown();
     this->rosQueue_.clear();
     this->rosQueue_.disable();
@@ -191,8 +191,8 @@ namespace gazebo {
         ///
         /// Publish wifi msg
 
-        math::Pose diff_pose  = (robot_ptr_->GetWorldPose() - parent_->GetWorldPose());
-        double ray_dist = sqrt(diff_pose.pos.GetSquaredLength());
+        ignition::math::Pose3d diff_pose = (robot_ptr_->WorldPose() - parent_->WorldPose());
+        double ray_dist = sqrt(diff_pose.Pos().SquaredLength());
         ROS_ERROR_STREAM("ray dist  " << ray_dist );
 
 
@@ -206,7 +206,7 @@ namespace gazebo {
       }
       else
       {
-        robot_ptr_ = this->world_->GetModel(this->robot_model_name_);
+        robot_ptr_ = this->world_->ModelByName(this->robot_model_name_);
         ROS_ERROR("Robot model not yet available, waiting ...");
 
       }

--- a/src/gazebo_world_odometry.cpp
+++ b/src/gazebo_world_odometry.cpp
@@ -1,6 +1,6 @@
 #include <assert.h>
 #include <pal_gazebo_plugins/gazebo_world_odometry.h>
-#include <gazebo/math/gzmath.hh>
+#include <ignition/math.hh>
 #include <sdf/sdf.hh>
 #include <ros/ros.h>
 #include <cmath>
@@ -48,7 +48,7 @@ namespace gazebo {
     std::string link_name_ = frame_name_;
     // assert that the body by link_name_ exists
     this->link = boost::dynamic_pointer_cast<gazebo::physics::Link>(
-      this->world_->GetEntity(link_name_));
+      this->world_->EntityByName(link_name_));
     if (!this->link)
     {
       ROS_FATAL("gazebo_ros_world_ogometry plugin error: bodyName: %s does not exist\n",
@@ -99,38 +99,30 @@ namespace gazebo {
 
     boost::mutex::scoped_lock sclock(this->mutex_);
 
-    gazebo::math::Pose pose;
-    gazebo::math::Quaternion orientation;
-    gazebo::math::Vector3 position;
-
-    pose = this->link->GetWorldPose();
-    position = pose.pos;
-    orientation = pose.rot;
-
-//    gazebo::math::Vector3 linearVel = this->link->GetWorldLinearVel();
-//    gazebo::math::Vector3 angularVel = this->link->GetWorldAngularVel();
-
-    gazebo::math::Vector3 linearVel = this->link->GetWorldLinearVel();
-    gazebo::math::Vector3 angularVel = this->link->GetRelativeAngularVel();
+    auto pose = this->link->WorldPose();
+    auto position = pose.Pos();
+    auto orientation = pose.Rot();
+    auto linearVel = this->link->WorldLinearVel();
+    auto angularVel = this->link->RelativeAngularVel();
 
     nav_msgs::Odometry odomMsg;
 
-    odomMsg.pose.pose.position.x = position.x;
-    odomMsg.pose.pose.position.y = position.y;
-    odomMsg.pose.pose.position.z = position.z;
+    odomMsg.pose.pose.position.x = position.X();
+    odomMsg.pose.pose.position.y = position.Y();
+    odomMsg.pose.pose.position.z = position.Z();
 
-    odomMsg.pose.pose.orientation.x = orientation.x;
-    odomMsg.pose.pose.orientation.y = orientation.y;
-    odomMsg.pose.pose.orientation.z = orientation.z;
-    odomMsg.pose.pose.orientation.w = orientation.w;
+    odomMsg.pose.pose.orientation.x = orientation.X();
+    odomMsg.pose.pose.orientation.y = orientation.Y();
+    odomMsg.pose.pose.orientation.z = orientation.Z();
+    odomMsg.pose.pose.orientation.w = orientation.W();
 
-    odomMsg.twist.twist.linear.x = linearVel.x;
-    odomMsg.twist.twist.linear.y = linearVel.y;
-    odomMsg.twist.twist.linear.z = linearVel.z;
+    odomMsg.twist.twist.linear.x = linearVel.X();
+    odomMsg.twist.twist.linear.y = linearVel.Y();
+    odomMsg.twist.twist.linear.z = linearVel.Z();
 
-    odomMsg.twist.twist.angular.x = angularVel.x;
-    odomMsg.twist.twist.angular.y = angularVel.y;
-    odomMsg.twist.twist.angular.z = angularVel.z;
+    odomMsg.twist.twist.angular.x = angularVel.X();
+    odomMsg.twist.twist.angular.y = angularVel.Y();
+    odomMsg.twist.twist.angular.z = angularVel.Z();
 
     odomMsg.header.frame_id = frame_name_;
 


### PR DESCRIPTION
This is a work-in-progress modification targeting ROS Melodic with Gazebo 9.

- [x] Replaced `gazebo::math` with `ignition::math`
- [x] Updated/replaced deprecated getters (now static properties) and setters (`SetUpperLimit()`)
- [ ] `event::Events::DisconnectWorldUpdateBegin(this->connection_);` is commented out for now
- [ ] (Not) tested and confirmed to work as intended

About the `Events` point: I still have to investigate whether updating connection at disconnect is required at all (I think not) and if so, how to put it properly into destructors (that's the recommended design now).

There are no unit tests for this package, so unfortunately I can't tell whether it works for now - I'm working on porting the full TIAGo simulation stack to Melodic but I'm not even done fixing all compilation errors yet.
However, with included changes this package compiles with no warnings.

@mwegiere FYI